### PR TITLE
feat: complete support and documentation for whisper-large-v3-turbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ fn main() {
 | `base`     | 142 MB | balanced ⭐   |
 | `small`    | 466 MB | accurate      |
 | `medium`   | 1.5 GB | very accurate |
+| `large-v3-turbo` | 1.6 GB | fast & accurate (advanced) |
 | `large-v3` | 3.0 GB | most accurate |
 
 Files are fetched from HuggingFace (`ggerganov/whisper.cpp`) and stored under `<app_data_dir>/whisper-models/`. The active model is persisted to `whisper-models/active.txt`.

--- a/guest-js/index.ts
+++ b/guest-js/index.ts
@@ -79,7 +79,7 @@ export interface PermissionResponse {
 
 /** Metadata for a single Whisper model in the catalogue. */
 export interface WhisperModelInfo {
-  /** Stable identifier (`tiny`, `tiny.en`, `base`, `base.en`, `small`, `small.en`, `medium`, `medium.en`, `large-v3`). */
+  /** Stable identifier (`tiny`, `tiny.en`, `base`, `base.en`, `small`, `small.en`, `medium`, `medium.en`, `large-v3-turbo`, `large-v3`). */
   id: string;
   /** Human-readable name shown in the model manager. */
   displayName: string;

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -166,16 +166,16 @@ const CATALOGUE: &[ModelSpec] = &[
         language: Some("en"),
         advanced: false,
     },
-    // 809 M params · ~6 GB VRAM · ~8× realtime — multilingual only.
-    // Faster than `medium` and almost as accurate, but the 6 GB working
-    // set rules out most laptops; advanced-only by default.
+    // 809 M params · ~3.5 GB VRAM · ~4× realtime — multilingual only.
+    // Pruned large-v3 decoder (32 → 4 layers); faster than `medium`
+    // and almost as accurate. Advanced-only by default.
     ModelSpec {
         id: "large-v3-turbo",
-        display_name: "Turbo",
+        display_name: "Large v3 Turbo",
         file_name: "ggml-large-v3-turbo.bin",
         url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin",
         size_mb: 1620,
-        required_memory_mb: 6144,
+        required_memory_mb: 3584,
         tier: "fast & accurate",
         recommended: false,
         language: None,

--- a/src/models.rs
+++ b/src/models.rs
@@ -241,7 +241,8 @@ pub struct SttError {
 #[serde(rename_all = "camelCase")]
 pub struct WhisperModelInfo {
     /// Stable identifier (`tiny`, `tiny.en`, `base`, `base.en`,
-    /// `small`, `small.en`, `medium`, `medium.en`, `large-v3`).
+    /// `small`, `small.en`, `medium`, `medium.en`, `large-v3-turbo`,
+    /// `large-v3`).
     pub id: String,
     /// Human-readable name shown in the model manager.
     pub display_name: String,


### PR DESCRIPTION
The `large-v3-turbo` model was partially implemented in the Rust backend catalog, but it was missing from all documentation/TypeScript types. Additionally, its memory requirements were copy-pasted from the full `large-v3` model, which artificially blocked devices with 8 GB system memory from installing it.

This PR corrects the model's catalog metadata and updates all user-facing documentation/types to fully expose it.

## Changes

### 1. Catalog spec correction in `src/desktop.rs`
- **Updated RAM/VRAM footprint**: Changed `required_memory_mb` from `6144` (6 GB) to `3584` (3.5 GB) to reflect the actual memory footprint of the distilled 809M parameter model. With the 30% headroom rule (`1.3 * 3.5 = ~4.6 GB` minimum system memory), this allows devices with 8 GB system RAM to run the model instead of being incorrectly greyed out.
- **Clarified name**: Changed `display_name` from `"Turbo"` to `"Large v3 Turbo"`.
- **Corrected comments**: Updated the catalog comment to reflect `~3.5 GB VRAM` and `~4x realtime` speedups (instead of `6 GB VRAM` and `8x realtime`).

### 2. Documentation and types
- **TypeScript JSDoc**: Added `large-v3-turbo` to the `WhisperModelInfo.id` field JSDoc in `guest-js/index.ts`.
- **Rust doc comments**: Added `large-v3-turbo` to the `WhisperModelInfo.id` struct field doc comment in `src/models.rs`.
- **README**: Added `large-v3-turbo` to the Model Catalogue table in `README.md` showing size and notes.

## Verification

### Automated Tests
Ran `cargo test` in workspace root. All 5 unit tests passed successfully:
```
test models::tests::test_permission_status_serialization ... ok
test models::tests::test_recognition_state_serialization ... ok
test models::tests::test_listen_config_defaults ... ok
test models::tests::test_recognition_result ... ok
test models::tests::test_listen_config_full ... ok
```

### JS/TS Bindings Compilation
Ran `bun run build` in the workspace root. Rollup successfully built the TypeScript API:
```
guest-js/index.ts → ./dist-js/index.js, ./dist-js/index.cjs...
created ./dist-js/index.js, ./dist-js/index.cjs in 465ms
```
